### PR TITLE
bound the read length so that the request fits in 4k boundary

### DIFF
--- a/lib/libtlp.c
+++ b/lib/libtlp.c
@@ -535,7 +535,7 @@ dma_read_aligned(struct nettlp *nt, uintptr_t addr, void *buf,
 		 size_t count, size_t mrrs)
 {
 	uintptr_t dma_addr;
-	size_t len, done;
+	size_t len, max_len, done;
 	ssize_t ret, dma_len;
 
 	done = 0;
@@ -543,7 +543,9 @@ dma_read_aligned(struct nettlp *nt, uintptr_t addr, void *buf,
 	dma_len = count;
 
 	do {
+		max_len = 0x1000 - (dma_addr & 0xFFF);
 		len = dma_len < mrrs ? dma_len : mrrs;
+		len = len < max_len ? len : max_len;
 		ret = dma_read(nt, dma_addr, buf + done, len);
 		if (ret < 0)
 			return ret;


### PR DESCRIPTION
PCIe does not allow a 4k address crossing request. Split requests in
such cases in `dma_read_aligned()`.

-----------------

I don't test it but I think `dma_write` also has the same problem.